### PR TITLE
switch to boost::asio

### DIFF
--- a/example/utility/io_context_runner.cpp
+++ b/example/utility/io_context_runner.cpp
@@ -3,7 +3,7 @@
 #include <csignal>
 #include <iostream>
 
-Io_context_runner::Io_context_runner(asio::io_context& io_context)
+Io_context_runner::Io_context_runner(boost::asio::io_context& io_context)
     : io_context_(io_context) {}
 
 Io_context_runner::~Io_context_runner() {
@@ -16,7 +16,7 @@ void Io_context_runner::set_signal_handler(
   signal_handler_ = signal_handler;
   add_signal(SIGINT);
   add_signal(SIGTERM);
-  signals_.async_wait([this](asio::error_code ec, int signal_number) {
+  signals_.async_wait([this](boost::system::error_code ec, int signal_number) {
     std::cout << "signal occurred: signal number = " << signal_number << '\n';
     if (ec) {
       std::cout << "signal occurred: error: " << ec.message() << " ("
@@ -29,8 +29,8 @@ void Io_context_runner::set_signal_handler(
 
 void Io_context_runner::start() {
   thread_ = std::thread([this] {
-    asio::executor_work_guard work_guard(io_context_.get_executor());
-    asio::io_context::count_type count = io_context_.run();
+    boost::asio::executor_work_guard work_guard(io_context_.get_executor());
+    boost::asio::io_context::count_type count = io_context_.run();
     std::cout << "number of IO context handlers executed = " << count << '\n';
   });
 }
@@ -41,7 +41,7 @@ void Io_context_runner::stop() {
 }
 
 void Io_context_runner::add_signal(int signal_number) {
-  asio::error_code ec;
+  boost::system::error_code ec;
   signals_.add(signal_number, ec);
   if (ec)
     std::cout << "add signal to signal set failure: " << ec.message() << " ("

--- a/example/utility/io_context_runner.h
+++ b/example/utility/io_context_runner.h
@@ -1,14 +1,14 @@
 #ifndef EXAMPLE_UTILITY_IO_CONTEXT_RUNNER_H
 #define EXAMPLE_UTILITY_IO_CONTEXT_RUNNER_H
 
-#include <asio.hpp>
+#include <boost/asio.hpp>
 
 #include <functional>
 #include <thread>
 
 class Io_context_runner {
 public:
-  explicit Io_context_runner(asio::io_context&);
+  explicit Io_context_runner(boost::asio::io_context&);
   ~Io_context_runner();
 
   void set_signal_handler(const std::function<void()>&);
@@ -17,8 +17,8 @@ public:
   void stop();
 
 private:
-  asio::io_context& io_context_;
-  asio::signal_set signals_{io_context_};
+  boost::asio::io_context& io_context_;
+  boost::asio::signal_set signals_{io_context_};
   std::function<void()> signal_handler_;
   std::thread thread_;
 

--- a/include/bc/soup/client/tcp_connection.h
+++ b/include/bc/soup/client/tcp_connection.h
@@ -16,15 +16,15 @@ public:
   Tcp_connection(Tcp_connection&&) = delete;
   Tcp_connection& operator=(Tcp_connection&&) = delete;
 
-  void connect_failure(asio::error_code) override;
+  void connect_failure(boost::system::error_code) override;
   void connect_success() override;
 
-  void read_failure(asio::error_code) override;
+  void read_failure(boost::system::error_code) override;
   void read_failure(Packet_error) override;
   void read_completed(const Read_packet&) override;
   void end_of_file() override;
 
-  void write_failure(asio::error_code) override;
+  void write_failure(boost::system::error_code) override;
   void write_completed(const Write_packet&) override;
   void write_buffer_empty() override;
 

--- a/include/bc/soup/server/acceptor.h
+++ b/include/bc/soup/server/acceptor.h
@@ -9,8 +9,8 @@ class Acceptor final : public Socket_acceptor::Handler {
 public:
   Acceptor();
 
-  void accept_failure(asio::error_code) override;
-  void accept_success(asio::ip::tcp::socket&&) override;
+  void accept_failure(boost::system::error_code) override;
+  void accept_success(boost::asio::ip::tcp::socket&&) override;
 
 private:
 };

--- a/include/bc/soup/server/tcp_connection.h
+++ b/include/bc/soup/server/tcp_connection.h
@@ -16,15 +16,15 @@ public:
   Tcp_connection(Tcp_connection&&) = delete;
   Tcp_connection& operator=(Tcp_connection&&) = delete;
 
-  void connect_failure(asio::error_code) override;
+  void connect_failure(boost::system::error_code) override;
   void connect_success() override;
 
-  void read_failure(asio::error_code) override;
+  void read_failure(boost::system::error_code) override;
   void read_failure(Packet_error) override;
   void read_completed(const Read_packet&) override;
   void end_of_file() override;
 
-  void write_failure(asio::error_code) override;
+  void write_failure(boost::system::error_code) override;
   void write_completed(const Write_packet&) override;
   void write_buffer_empty() override;
 

--- a/include/bc/soup/socket.h
+++ b/include/bc/soup/socket.h
@@ -4,7 +4,7 @@
 #include "bc/soup/rw_packets.h"
 #include "bc/soup/types.h"
 
-#include <asio.hpp>
+#include <boost/asio.hpp>
 
 #include <cstddef>
 #include <list>
@@ -15,15 +15,15 @@ class Socket {
 public:
   class Handler {
   public:
-    virtual void connect_failure(asio::error_code) = 0;
+    virtual void connect_failure(boost::system::error_code) = 0;
     virtual void connect_success() = 0;
 
-    virtual void read_failure(asio::error_code) = 0;
+    virtual void read_failure(boost::system::error_code) = 0;
     virtual void read_failure(Packet_error) = 0;
     virtual void read_completed(const Read_packet&) = 0;
     virtual void end_of_file() = 0;
 
-    virtual void write_failure(asio::error_code) = 0;
+    virtual void write_failure(boost::system::error_code) = 0;
     virtual void write_completed(const Write_packet&) = 0;
     virtual void write_buffer_empty() = 0;
 
@@ -38,10 +38,10 @@ public:
     Handler& operator=(Handler&&) = default;
   };
 
-  explicit Socket(asio::any_io_executor);
-  Socket(asio::any_io_executor, Handler&);
-  explicit Socket(asio::ip::tcp::socket&&);
-  Socket(asio::ip::tcp::socket&&, Handler&);
+  explicit Socket(boost::asio::any_io_executor);
+  Socket(boost::asio::any_io_executor, Handler&);
+  explicit Socket(boost::asio::ip::tcp::socket&&);
+  Socket(boost::asio::ip::tcp::socket&&, Handler&);
   ~Socket() = default;
 
   Socket(const Socket&) = delete;
@@ -53,36 +53,36 @@ public:
   void set_handler(Handler&);
   void set_write_packets_limit(std::size_t);
 
-  [[nodiscard]] asio::error_code open();
-  void shutdown(asio::error_code* = nullptr);
-  void close(asio::error_code* = nullptr);
+  [[nodiscard]] boost::system::error_code open();
+  void shutdown(boost::system::error_code* = nullptr);
+  void close(boost::system::error_code* = nullptr);
 
-  [[nodiscard]] asio::error_code set_no_delay();
+  [[nodiscard]] boost::system::error_code set_no_delay();
 
-  void async_connect(const asio::ip::tcp::endpoint&);
+  void async_connect(const boost::asio::ip::tcp::endpoint&);
 
   void async_read();
   Write_error async_write(Write_packet&&);
 
-  asio::ip::tcp::endpoint local_endpoint(asio::error_code* = nullptr) const;
-  asio::ip::tcp::endpoint remote_endpoint(asio::error_code* = nullptr) const;
+  boost::asio::ip::tcp::endpoint local_endpoint(boost::system::error_code* = nullptr) const;
+  boost::asio::ip::tcp::endpoint remote_endpoint(boost::system::error_code* = nullptr) const;
 
-  asio::ip::tcp::socket::executor_type get_executor();
+  boost::asio::ip::tcp::socket::executor_type get_executor();
 
 private:
   Handler* handler_ = nullptr;
-  asio::ip::tcp::socket socket_;
+  boost::asio::ip::tcp::socket socket_;
   Read_packet read_packet_;
   std::list<Write_packet> write_packets_;
   std::size_t write_packets_limit_ = 100;
   bool write_buffer_was_full_ = false;
 
   void read_header();
-  void header_received(asio::error_code, std::size_t);
+  void header_received(boost::system::error_code, std::size_t);
   void read_payload();
-  void payload_received(asio::error_code, std::size_t);
+  void payload_received(boost::system::error_code, std::size_t);
   void write_packet();
-  void packet_sent(asio::error_code, std::size_t);
+  void packet_sent(boost::system::error_code, std::size_t);
 };
 
 } // namespace bc::soup

--- a/include/bc/soup/socket_acceptor.h
+++ b/include/bc/soup/socket_acceptor.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDE_BC_SOUP_SOCKET_ACCEPTOR_H
 #define INCLUDE_BC_SOUP_SOCKET_ACCEPTOR_H
 
-#include <asio.hpp>
+#include <boost/asio.hpp>
 
 #include <optional>
 
@@ -11,8 +11,8 @@ class Socket_acceptor {
 public:
   class Handler {
   public:
-    virtual void accept_failure(asio::error_code) = 0;
-    virtual void accept_success(asio::ip::tcp::socket&&) = 0;
+    virtual void accept_failure(boost::system::error_code) = 0;
+    virtual void accept_success(boost::asio::ip::tcp::socket&&) = 0;
 
   protected:
     Handler() = default;
@@ -25,8 +25,8 @@ public:
     Handler& operator=(Handler&&) = default;
   };
 
-  explicit Socket_acceptor(asio::any_io_executor);
-  Socket_acceptor(asio::any_io_executor, Handler&);
+  explicit Socket_acceptor(boost::asio::any_io_executor);
+  Socket_acceptor(boost::asio::any_io_executor, Handler&);
   ~Socket_acceptor() = default;
 
   Socket_acceptor(const Socket_acceptor&) = delete;
@@ -37,24 +37,24 @@ public:
 
   void set_handler(Handler&);
 
-  [[nodiscard]] asio::error_code open();
-  [[nodiscard]] asio::error_code bind(const asio::ip::tcp::endpoint&);
-  [[nodiscard]] asio::error_code listen();
-  void close(asio::error_code* = nullptr);
+  [[nodiscard]] boost::system::error_code open();
+  [[nodiscard]] boost::system::error_code bind(const boost::asio::ip::tcp::endpoint&);
+  [[nodiscard]] boost::system::error_code listen();
+  void close(boost::system::error_code* = nullptr);
 
-  [[nodiscard]] asio::error_code set_reuse_address();
-  [[nodiscard]] asio::error_code set_no_delay();
+  [[nodiscard]] boost::system::error_code set_reuse_address();
+  [[nodiscard]] boost::system::error_code set_no_delay();
 
   void async_accept();
 
-  asio::ip::tcp::endpoint local_endpoint(asio::error_code* = nullptr) const;
+  boost::asio::ip::tcp::endpoint local_endpoint(boost::system::error_code* = nullptr) const;
 
-  asio::ip::tcp::acceptor::executor_type get_executor();
+  boost::asio::ip::tcp::acceptor::executor_type get_executor();
 
 private:
   Handler* handler_ = nullptr;
-  asio::ip::tcp::acceptor acceptor_;
-  std::optional<asio::ip::tcp::socket> socket_;
+  boost::asio::ip::tcp::acceptor acceptor_;
+  std::optional<boost::asio::ip::tcp::socket> socket_;
 };
 
 } // namespace bc::soup

--- a/src/client/tcp_connection.cpp
+++ b/src/client/tcp_connection.cpp
@@ -4,11 +4,11 @@ namespace bc::soup::client {
 
 Tcp_connection::Tcp_connection() {}
 
-void Tcp_connection::connect_failure(asio::error_code) {}
+void Tcp_connection::connect_failure(boost::system::error_code) {}
 
 void Tcp_connection::connect_success() {}
 
-void Tcp_connection::read_failure(asio::error_code) {}
+void Tcp_connection::read_failure(boost::system::error_code) {}
 
 void Tcp_connection::read_failure(Packet_error) {}
 
@@ -16,7 +16,7 @@ void Tcp_connection::read_completed(const Read_packet&) {}
 
 void Tcp_connection::end_of_file() {}
 
-void Tcp_connection::write_failure(asio::error_code) {}
+void Tcp_connection::write_failure(boost::system::error_code) {}
 
 void Tcp_connection::write_completed(const Write_packet&) {}
 

--- a/src/server/acceptor.cpp
+++ b/src/server/acceptor.cpp
@@ -4,8 +4,8 @@ namespace bc::soup::server {
 
 Acceptor::Acceptor() {}
 
-void Acceptor::accept_failure(asio::error_code) {}
+void Acceptor::accept_failure(boost::system::error_code) {}
 
-void Acceptor::accept_success(asio::ip::tcp::socket&&) {}
+void Acceptor::accept_success(boost::asio::ip::tcp::socket&&) {}
 
 } // namespace bc::soup::server

--- a/src/server/tcp_connection.cpp
+++ b/src/server/tcp_connection.cpp
@@ -4,11 +4,11 @@ namespace bc::soup::server {
 
 Tcp_connection::Tcp_connection() {}
 
-void Tcp_connection::connect_failure(asio::error_code) {}
+void Tcp_connection::connect_failure(boost::system::error_code) {}
 
 void Tcp_connection::connect_success() {}
 
-void Tcp_connection::read_failure(asio::error_code) {}
+void Tcp_connection::read_failure(boost::system::error_code) {}
 
 void Tcp_connection::read_failure(Packet_error) {}
 
@@ -16,7 +16,7 @@ void Tcp_connection::read_completed(const Read_packet&) {}
 
 void Tcp_connection::end_of_file() {}
 
-void Tcp_connection::write_failure(asio::error_code) {}
+void Tcp_connection::write_failure(boost::system::error_code) {}
 
 void Tcp_connection::write_completed(const Write_packet&) {}
 

--- a/src/socket_acceptor.cpp
+++ b/src/socket_acceptor.cpp
@@ -4,59 +4,58 @@
 
 namespace bc::soup {
 
-Socket_acceptor::Socket_acceptor(asio::any_io_executor io_executor)
+Socket_acceptor::Socket_acceptor(boost::asio::any_io_executor io_executor)
     : acceptor_(io_executor) {}
 
-Socket_acceptor::Socket_acceptor(asio::any_io_executor io_executor,
+Socket_acceptor::Socket_acceptor(boost::asio::any_io_executor io_executor,
                                  Handler& handler)
     : handler_(&handler), acceptor_(io_executor) {}
 
 void Socket_acceptor::set_handler(Handler& handler) { handler_ = &handler; }
 
-asio::error_code Socket_acceptor::open() {
-  asio::error_code ec;
-  acceptor_.open(asio::ip::tcp::v4(), ec);
+boost::system::error_code Socket_acceptor::open() {
+  boost::system::error_code ec;
+  acceptor_.open(boost::asio::ip::tcp::v4(), ec);
   return ec;
 }
 
-asio::error_code
-Socket_acceptor::bind(const asio::ip::tcp::endpoint& endpoint) {
-  asio::error_code ec;
+boost::system::error_code Socket_acceptor::bind(const boost::asio::ip::tcp::endpoint& endpoint) {
+  boost::system::error_code ec;
   acceptor_.bind(endpoint, ec);
   return ec;
 }
 
-asio::error_code Socket_acceptor::listen() {
-  asio::error_code ec;
-  acceptor_.listen(asio::socket_base::max_listen_connections, ec);
+boost::system::error_code Socket_acceptor::listen() {
+  boost::system::error_code ec;
+  acceptor_.listen(boost::asio::socket_base::max_listen_connections, ec);
   return ec;
 }
 
-void Socket_acceptor::close(asio::error_code* error) {
-  asio::error_code ec;
+void Socket_acceptor::close(boost::system::error_code* error) {
+  boost::system::error_code ec;
   acceptor_.close(ec);
   if (error)
     *error = ec;
 }
 
-asio::error_code Socket_acceptor::set_reuse_address() {
-  asio::ip::tcp::acceptor::reuse_address option(true);
-  asio::error_code ec;
+boost::system::error_code Socket_acceptor::set_reuse_address() {
+  boost::asio::ip::tcp::acceptor::reuse_address option(true);
+  boost::system::error_code ec;
   acceptor_.set_option(option, ec);
   return ec;
 }
 
-asio::error_code Socket_acceptor::set_no_delay() {
-  asio::ip::tcp::no_delay option(true);
-  asio::error_code ec;
+boost::system::error_code Socket_acceptor::set_no_delay() {
+  boost::asio::ip::tcp::no_delay option(true);
+  boost::system::error_code ec;
   acceptor_.set_option(option, ec);
   return ec;
 }
 
 void Socket_acceptor::async_accept() {
   socket_.emplace(acceptor_.get_executor());
-  acceptor_.async_accept(*socket_, [this](asio::error_code ec) {
-    if (ec == asio::error::operation_aborted) {
+  acceptor_.async_accept(*socket_, [this](boost::system::error_code ec) {
+    if (ec == boost::asio::error::operation_aborted) {
       return;
     }
     if (ec) {
@@ -67,16 +66,16 @@ void Socket_acceptor::async_accept() {
   });
 }
 
-asio::ip::tcp::endpoint
-Socket_acceptor::local_endpoint(asio::error_code* error) const {
-  asio::error_code ec;
+boost::asio::ip::tcp::endpoint
+Socket_acceptor::local_endpoint(boost::system::error_code* error) const {
+  boost::system::error_code ec;
   auto endpoint = acceptor_.local_endpoint(ec);
   if (error)
     *error = ec;
   return endpoint;
 }
 
-asio::ip::tcp::acceptor::executor_type Socket_acceptor::get_executor() {
+boost::asio::ip::tcp::acceptor::executor_type Socket_acceptor::get_executor() {
   return acceptor_.get_executor();
 }
 


### PR DESCRIPTION
Some users are already using boost, and not the separate asio library. This PR changes the namespace to compile with Boost. 